### PR TITLE
Support present server timing headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -259,7 +259,7 @@ class ServerTiming {
       .reduce((metrics, callback) => {
         return callback(metrics)
       }, this.metrics)
-    const metrics = Object.entries(updatedMetrics).reduce(
+    let metrics = Object.entries(updatedMetrics).reduce(
       (collector, element) => {
         const [name, { from, to, description, duration }] = element
         collector.push(
@@ -278,6 +278,17 @@ class ServerTiming {
       },
       []
     )
+
+    if (
+      Array.isArray(response.headers['server-timing']) &&
+      response.headers['server-timing'].length > 0
+    ) {
+      metrics = [
+        ...response.headers['server-timing'],
+        ...metrics
+      ]
+    }
+
     if (metrics.length > 0) response.set(HEADER_NAME, metrics)
     this.metrics = {}
   }

--- a/index.test.js
+++ b/index.test.js
@@ -219,6 +219,33 @@ describe('server Timing middleware should', () => {
     )
   })
 
+  it('would not rewrite headers added by other application', () => {
+    expect.assertions(3)
+    const next = jest.fn()
+    const request = new Request()
+    const response = new Response()
+    const presentHeader = 'db;dur=53, app;dur=47.2'
+    response.headers = {
+      'server-timing': [
+        presentHeader
+      ]
+    }
+
+    middleware({ sendHeaders: false })(request, response, next)
+
+    request.serverTiming.add(
+      'userData',
+      'getting user data from user microservice',
+      123
+    )
+    request.serverTiming.duration('userData', 234)
+    request.serverTiming.addHeaders(response)
+
+    expect(response.headers).toHaveProperty('server-timing')
+    expect(response.headers['server-timing']).toHaveLength(2)
+    expect(response.headers['server-timing'].includes(presentHeader)).toBe(true)
+  })
+
   it('allow add hook to modify the data before add headers', () => {
     expect.assertions(2)
     const next = jest.fn()


### PR DESCRIPTION
Before if something else set timing headers, middleware would rewrite them.
Now it's handled properly.